### PR TITLE
Disable generating man pages

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -24,7 +24,7 @@ else
     LDFLAGS="-L$prefix/lib -Wl,-rpath-link,$prefix/lib"
 fi
 make -j${nproc} LDFLAGS="$LDFLAGS"
-make install
+make install-exec
 
 """
 


### PR DESCRIPTION
The `share/man/` directory is still produced with this change, but it remains empty