### PR TITLE
Update CURL, MbedTLS, and Zlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
+  - 1.0
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ sudo: required
 
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", version=v"0.1.4"), PackageSpec(name="MbedTLS", version=v"0.6.6"), PackageSpec(name="BinaryProvider")])'
+  # MbedTLS version is pinned to 0.6.6 because 0.6.7 is currently broken. see https://github.com/JuliaWeb/MbedTLS.jl/issues/193
+  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder"), PackageSpec(name="MbedTLS", version=v"0.6.6"), PackageSpec(name="BinaryProvider")])'
 
 script:
   - julia build_tarballs.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: required
 
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", rev="master"), PackageSpec(name="MbedTLS", version=v"0.6.6"), PackageSpec(name="BinaryProvider")])'
+  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", version=v"0.1.4"), PackageSpec(name="MbedTLS", version=v"0.6.6"), PackageSpec(name="BinaryProvider")])'
 
 script:
   - julia build_tarballs.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: required
 
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", rev="master"), PackageSpec(name="BinaryProvider")])'
+  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", rev="master"), PackageSpec(name="MbedTLS", version=v"0.6.6"), PackageSpec(name="BinaryProvider")])'
 
 script:
   - julia build_tarballs.jl

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -15,21 +15,13 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/curl-7.64.0
 
-# Set up ca path/bundle
-ca_args=""
-if [[ $target == x86_64-apple-darwin14 ]]; then
-    ca_args="--with-ca-bundle=/etc/ssl/cert.pem"
-elif [[ $target == *-linux-* ]]; then
-    ca_args="--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt"
-fi
-
 # Configure and build
 ./configure \
     --prefix=$prefix \
     --host=$target \
     --with-mbedtls \
     --without-ssl \
-    --disable-manual $ca_args
+    --disable-manual
 
 if [[ $target == *-w64-mingw32 ]]; then
     LDFLAGS="$LDFLAGS -L$prefix/bin"

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,18 +3,17 @@
 using BinaryBuilder
 
 name = "LibCURL"
-version = v"7.61.0"
+version = v"7.64.0"
 
 # Collection of sources required to build LibCURL
 sources = [
-    "https://curl.haxx.se/download/curl-7.61.0.tar.gz" =>
-    "64141f0db4945268a21b490d58806b97c615d3d0c75bf8c335bbe0efd13b45b5",
-
+    "https://curl.haxx.se/download/curl-7.64.0.tar.gz" =>
+    "cb90d2eb74d4e358c1ed1489f8e3af96b50ea4374ad71f143fa4595e998d81b5",
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/curl-7.61.0
+cd $WORKSPACE/srcdir/curl-7.64.0
 ./configure --prefix=$prefix --host=$target --with-mbedtls --without-ssl --disable-manual
 if [[ $target == *-w64-mingw32 ]]; then
     LDFLAGS="-L$prefix/bin"
@@ -25,23 +24,21 @@ else
 fi
 make -j${nproc} LDFLAGS="$LDFLAGS"
 make install-exec
-
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, :glibc),
-    Linux(:x86_64, :glibc),
-    Linux(:aarch64, :glibc),
-    Linux(:armv7l, :glibc, :eabihf),
-    Linux(:powerpc64le, :glibc),
-    Linux(:i686, :musl),
-    Linux(:x86_64, :musl),
-    Linux(:aarch64, :musl),
-    Linux(:armv7l, :musl, :eabihf),
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
     MacOS(:x86_64),
-    FreeBSD(:x86_64),
     Windows(:i686),
     Windows(:x86_64),
 ]
@@ -53,10 +50,15 @@ products(prefix) = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.2/build_Zlib.v1.2.11.jl",
-    "https://github.com/JuliaWeb/MbedTLSBuilder/releases/download/v0.11/build_MbedTLS.v1.0.0.jl"
+    string(
+        "https://github.com/JuliaWeb/MbedTLSBuilder/releases/download/",
+        "v0.17.0/build_MbedTLS.v2.16.0.jl",
+    ),
+    string(
+        "https://github.com/bicycle1885/ZlibBuilder/releases/download/",
+        "v1.0.3/build_Zlib.v1.2.11.jl",
+    ),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
- CURL: 7.61.0 -> 7.64.0
- MbedTLS: 0.11.0 -> 0.17.0
- Zlib: 1.0.2 -> 1.0.3
- FreeBSD Doesn't seem to want to compile anymore possibly due to https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/390 
- MbedTLS version in .travis.yml is pinned to 0.6.6 because 0.6.7 is currently broken. see https://github.com/JuliaWeb/MbedTLS.jl/issues/193