### PR TITLE
Re-add FreeBSD support

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -50,7 +50,7 @@ dependencies = [
     ),
     string(
         "https://github.com/bicycle1885/ZlibBuilder/releases/download/",
-        "v1.0.3/build_Zlib.v1.2.11.jl",
+        "v1.0.4/build_Zlib.v1.2.11.jl",
     ),
 ]
 

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -46,7 +46,7 @@ products(prefix) = [
 dependencies = [
     string(
         "https://github.com/JuliaWeb/MbedTLSBuilder/releases/download/",
-        "v0.17.0/build_MbedTLS.v2.16.0.jl",
+        "v0.20.0/build_MbedTLS.v2.6.1.jl",
     ),
     string(
         "https://github.com/bicycle1885/ZlibBuilder/releases/download/",

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -34,22 +34,8 @@ make -j${nproc} LDFLAGS="$LDFLAGS"
 make install-exec
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64),
-]
+# Build for ALL THE PLATFORMS!
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,17 +3,17 @@
 using BinaryBuilder
 
 name = "LibCURL"
-version = v"7.64.0"
+version = v"7.64.1"
 
 # Collection of sources required to build LibCURL
 sources = [
-    "https://curl.haxx.se/download/curl-7.64.0.tar.gz" =>
-    "cb90d2eb74d4e358c1ed1489f8e3af96b50ea4374ad71f143fa4595e998d81b5",
+    "https://curl.haxx.se/download/curl-7.64.1.tar.gz" =>
+    "432d3f466644b9416bc5b649d344116a753aeaa520c8beaf024a90cba9d3d35d",
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/curl-7.64.0
+cd $WORKSPACE/srcdir/curl-7.64.1
 
 # Configure and build
 ./configure \
@@ -39,7 +39,8 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [
-    LibraryProduct(prefix, "libcurl", :libcurl)
+    LibraryProduct(prefix, "libcurl", :libcurl),
+    ExecutableProduct(prefix, "curl", :curl)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -44,15 +44,10 @@ products(prefix) = [
 ]
 
 # Dependencies that must be installed before this package can be built
+gh = "https://github.com"
 dependencies = [
-    string(
-        "https://github.com/JuliaWeb/MbedTLSBuilder/releases/download/",
-        "v0.20.0/build_MbedTLS.v2.6.1.jl",
-    ),
-    string(
-        "https://github.com/bicycle1885/ZlibBuilder/releases/download/",
-        "v1.0.4/build_Zlib.v1.2.11.jl",
-    ),
+    "$gh/JuliaWeb/MbedTLSBuilder/releases/download/v0.20.0/build_MbedTLS.v2.6.1.jl",
+    "$gh/bicycle1885/ZlibBuilder/releases/download/v1.0.4/build_Zlib.v1.2.11.jl",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -30,7 +30,7 @@ elif [[ $target == x86_64-apple-darwin14 ]]; then
 else
     LDFLAGS="$LDFLAGS -L$prefix/lib -Wl,-rpath-link,$prefix/lib"
 fi
-make -j${nproc} LDFLAGS="$LDFLAGS"
+make -j${nproc} LDFLAGS="$LDFLAGS" CPPFLAGS="$CPPFLAGS -I$prefix/include"
 make install-exec
 """
 


### PR DESCRIPTION
Previously FreeBSD support was dropped in https://github.com/JuliaWeb/LibCURLBuilder/pull/12. An update to ZlibBuilder has corrected the problem and we can now support FreeBSD here as well. In order to support FreeBSD we also needed to add `-I$prefix/include`.

Fixes: https://github.com/JuliaWeb/LibCURLBuilder/issues/13