### PR TITLE
Remove unneeded ExecutableProduct again

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -38,9 +38,11 @@ make install-exec
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
+# Note: Avoid including the `curl` executable as it is unneeded and requires additional
+# configuration to work.
 products(prefix) = [
     LibraryProduct(prefix, "libcurl", :libcurl),
-    ExecutableProduct(prefix, "curl", :curl)
+    # ExecutableProduct(prefix, "curl", :curl)
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Using the executable doesn't work out of the box (at least on macOS):

```julia
run(`$(LibCURL.curl) -v`)
dyld: Library not loaded: @rpath/libmbedtls.10.dylib
  Referenced from: /Users/omus/.julia/dev/LibCURL/deps/usr/bin/curl
  Reason: image not found
ERROR: failed process: Process(`/Users/omus/.julia/dev/LibCURL/deps/usr/bin/curl -v`, ProcessSignaled(6)) [0]
```

Additionally, there were some issues in the past with the LibCURLBuilder
`curl` interfering with using the system `curl`:

https://github.com/JuliaWeb/LibCURL.jl/pull/50

I'll note that previously we had removed this functionality https://github.com/JuliaWeb/LibCURLBuilder/pull/8 but since we didn't leave a comment as to why this was removed I accidentally re-added it :S.